### PR TITLE
Update dt2 boss utilities

### DIFF
--- a/plugins/dt2-mistake-tracker
+++ b/plugins/dt2-mistake-tracker
@@ -1,3 +1,3 @@
 repository=https://github.com/DominickCobb-rs/DT2-Boss-Failure.git
-commit=e6792347a8f36bc3e70943f8ba10b478232c5172
+commit=ef8a7cb0448d95d2876469cdc45d3965c53b41ca
 authors=DominickCobb


### PR DESCRIPTION
disable whisperer projectile swap